### PR TITLE
Lineup selector drag drop

### DIFF
--- a/frontend/src/CSS/LeaguePages.css
+++ b/frontend/src/CSS/LeaguePages.css
@@ -195,3 +195,12 @@
   background-color: #f0f0f0;
   opacity: 0.7;
 }
+
+.lineup-drop-valid {
+  outline: 2px dashed rgba(0, 123, 255, 0.6);
+  outline-offset: -2px;
+}
+
+.lineup-drop-over {
+  background-color: rgba(0, 123, 255, 0.12) !important;
+}

--- a/frontend/src/Components/AdjustLineups/index.tsx
+++ b/frontend/src/Components/AdjustLineups/index.tsx
@@ -21,6 +21,8 @@ import { TeamSelectionDropdown } from "../shared/TeamSelectionDropdown";
 import { QuicksetDropdown } from "../shared/QuicksetDropdown";
 import { useUpdateAllTeamsMutation } from "../../hooks/query/useQuicksetAllTeamsMutation";
 import { QuicksetAllDropdown } from "./QuicksetAllDropdown";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 
 export default function AdjustLineups() {
   const { id } = useParams() as { id: string };
@@ -116,54 +118,56 @@ export default function AdjustLineups() {
         league &&
         scheduleQuery.isSuccess &&
         defenseStatsQuery.isSuccess && (
-          <Row className="mt-3">
-            <Col sm={2}>
-              <h2>{selectedTeam.name}</h2>
-            </Col>
-            <Col>
-              <QuicksetDropdown
-                week={week}
-                mutationFn={setHighestProjectedLineupMutation}
-                lineupSettings={league.lineupSettings}
-              />
-            </Col>
-            <Col xs={12}>
-              <h4>Starters</h4>
-            </Col>
-            <Col xs={12}>
-              <TeamTable
-                players={currentLineup}
-                positionsInTable={league.lineupSettings}
-                name="starters"
-                nflDefenseStats={defenseStatsQuery.data?.data}
-                nflSchedule={scheduleQuery.data}
-                week={week.toString() as Week}
-                handleBenchPlayer={onBench}
-                handlePlayerChange={onPlayerChange}
-                isOwner
-                isAdmin
-                teamId={selectedTeam.id}
-              />
-            </Col>
-            <Col xs={12}>
-              <h4>Bench</h4>
-            </Col>
-            <Col xs={12}>
-              <TeamTable
-                players={currentLineup}
-                positionsInTable={{ bench: 1 } as LineupSettings}
-                name="bench"
-                nflDefenseStats={defenseStatsQuery.data?.data}
-                nflSchedule={scheduleQuery.data}
-                week={week.toString() as Week}
-                handleBenchPlayer={onBench}
-                handlePlayerChange={onPlayerChange}
-                isOwner
-                isAdmin
-                teamId={selectedTeam.id}
-              />
-            </Col>
-          </Row>
+          <DndProvider backend={HTML5Backend}>
+            <Row className="mt-3">
+              <Col sm={2}>
+                <h2>{selectedTeam.name}</h2>
+              </Col>
+              <Col>
+                <QuicksetDropdown
+                  week={week}
+                  mutationFn={setHighestProjectedLineupMutation}
+                  lineupSettings={league.lineupSettings}
+                />
+              </Col>
+              <Col xs={12}>
+                <h4>Starters</h4>
+              </Col>
+              <Col xs={12}>
+                <TeamTable
+                  players={currentLineup}
+                  positionsInTable={league.lineupSettings}
+                  name="starters"
+                  nflDefenseStats={defenseStatsQuery.data?.data}
+                  nflSchedule={scheduleQuery.data}
+                  week={week.toString() as Week}
+                  handleBenchPlayer={onBench}
+                  handlePlayerChange={onPlayerChange}
+                  isOwner
+                  isAdmin
+                  teamId={selectedTeam.id}
+                />
+              </Col>
+              <Col xs={12}>
+                <h4>Bench</h4>
+              </Col>
+              <Col xs={12}>
+                <TeamTable
+                  players={currentLineup}
+                  positionsInTable={{ bench: 1 } as LineupSettings}
+                  name="bench"
+                  nflDefenseStats={defenseStatsQuery.data?.data}
+                  nflSchedule={scheduleQuery.data}
+                  week={week.toString() as Week}
+                  handleBenchPlayer={onBench}
+                  handlePlayerChange={onPlayerChange}
+                  isOwner
+                  isAdmin
+                  teamId={selectedTeam.id}
+                />
+              </Col>
+            </Row>
+          </DndProvider>
         )}
       {(setHighestProjectedLineupMutation.isLoading ||
         updateAllLineups.isLoading) && <div className="spinning-loader" />}

--- a/frontend/src/Components/TeamPage/index.tsx
+++ b/frontend/src/Components/TeamPage/index.tsx
@@ -5,6 +5,8 @@ import cloneDeep from "lodash/cloneDeep";
 import { useMemo, useState } from "react";
 import { Button, ButtonGroup, Col, Container, Row, Toast } from "react-bootstrap";
 import { useParams } from "react-router-dom";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 import "../../CSS/LeaguePages.css";
 import { auth, storage } from "../../firebase-config";
 import { useSingleTeam } from "../../hooks/query/useSingleTeam";
@@ -220,39 +222,41 @@ const TeamPage = () => {
           <Row>
             <h3>Starters</h3>
           </Row>
-          <Row>
-            <TeamTable
-              isOwner={user.data?.uid === team.owner && canEditRoster}
-              players={lineup}
-              positionsInTable={league.lineupSettings}
-              nflSchedule={nflScheduleQuery?.data}
-              nflDefenseStats={defenseStatsQuery?.data?.data}
-              name="starters"
-              week={week.toString() as Week}
-              handleBenchPlayer={onBench}
-              handlePlayerChange={onChange}
-              showScores={true}
-              leagueId={leagueId}
-            />
-          </Row>
-          <Row>
-            <h3>Bench</h3>
-          </Row>
-          <Row>
-            <TeamTable
-              isOwner={user.data?.uid === team.owner && canEditRoster}
-              players={lineup}
-              positionsInTable={{ bench: 1 } as LineupSettings}
-              nflSchedule={nflScheduleQuery?.data}
-              nflDefenseStats={defenseStatsQuery?.data?.data}
-              name="bench"
-              week={week.toString() as Week}
-              handleBenchPlayer={onBench}
-              handlePlayerChange={onChange}
-              showScores={true}
-              leagueId={leagueId}
-            />
-          </Row>
+          <DndProvider backend={HTML5Backend}>
+            <Row>
+              <TeamTable
+                isOwner={user.data?.uid === team.owner && canEditRoster}
+                players={lineup}
+                positionsInTable={league.lineupSettings}
+                nflSchedule={nflScheduleQuery?.data}
+                nflDefenseStats={defenseStatsQuery?.data?.data}
+                name="starters"
+                week={week.toString() as Week}
+                handleBenchPlayer={onBench}
+                handlePlayerChange={onChange}
+                showScores={true}
+                leagueId={leagueId}
+              />
+            </Row>
+            <Row>
+              <h3>Bench</h3>
+            </Row>
+            <Row>
+              <TeamTable
+                isOwner={user.data?.uid === team.owner && canEditRoster}
+                players={lineup}
+                positionsInTable={{ bench: 1 } as LineupSettings}
+                nflSchedule={nflScheduleQuery?.data}
+                nflDefenseStats={defenseStatsQuery?.data?.data}
+                name="bench"
+                week={week.toString() as Week}
+                handleBenchPlayer={onBench}
+                handlePlayerChange={onChange}
+                showScores={true}
+                leagueId={leagueId}
+              />
+            </Row>
+          </DndProvider>
           <SuperflexModal
             leagueLineupSettings={league.lineupSettings}
             show={showSuperflexModal}

--- a/frontend/src/Components/shared/PlayerActionButton/index.tsx
+++ b/frontend/src/Components/shared/PlayerActionButton/index.tsx
@@ -8,6 +8,7 @@ interface PlayerActionButtonProps {
     player: FinalizedPlayer;
     oppositePlayers: FinalizedPlayer[];
     disabled: boolean;
+    selectedIndex: number;
     handlePlayerChange: (
         player: FinalizedPlayer,
         name: TableType,
@@ -25,6 +26,7 @@ export const PlayerActionButton: React.FC<PlayerActionButtonProps> = ({
     player,
     oppositePlayers,
     disabled,
+    selectedIndex,
     handlePlayerChange,
     handleBenchPlayer,
     teamId,
@@ -38,7 +40,7 @@ export const PlayerActionButton: React.FC<PlayerActionButtonProps> = ({
                     <Dropdown.Item
                         key={j}
                         onClick={() =>
-                            handlePlayerChange(player, tableType, oppPlayer, -1, teamId)
+                            handlePlayerChange(player, tableType, oppPlayer, selectedIndex, teamId)
                         }
                     >
                         {oppPlayer.lineup}: {oppPlayer.fullName}


### PR DESCRIPTION
Add drag-and-drop functionality to the lineup selector to allow intuitive player swaps between valid positions, including visual highlighting for valid drop targets.

This feature reuses the existing `react-dnd` library and integrates with the current player swap logic, providing a more direct and visual way to manage lineups.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddda274b-78d6-4a17-b268-a4833b6f377e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddda274b-78d6-4a17-b268-a4833b6f377e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

